### PR TITLE
Refactor: Remove static return buffers from filesystem API

### DIFF
--- a/lib/include/cfd/core/filesystem.h
+++ b/lib/include/cfd/core/filesystem.h
@@ -40,8 +40,8 @@ void cfd_set_output_base_dir(const char* path);
 // Set default path mode when custom base not specified
 void cfd_set_default_path_mode(cfd_default_path_mode_t mode);
 
-// Get current base path (returns custom or default based on mode)
-const char* cfd_get_artifacts_path(void);
+// Get current base path (copies to buffer)
+void cfd_get_artifacts_path(char* buffer, size_t size);
 
 // Reset to default path mode
 void cfd_reset_artifacts_path(void);
@@ -73,8 +73,8 @@ void cfd_create_run_directory_with_prefix(char* buffer, size_t buffer_size, cons
 void cfd_create_run_directory_ex(char* buffer, size_t buffer_size, const char* solver_name,
                                  size_t nx, size_t ny);
 
-// Get current run directory (NULL if not yet created)
-const char* cfd_get_run_directory(void);
+// Get current run directory (copies to buffer, empty string if not created)
+void cfd_get_run_directory(char* buffer, size_t size);
 
 // Reset run directory for new simulation
 void cfd_reset_run_directory(void);

--- a/lib/src/core/filesystem.c
+++ b/lib/src/core/filesystem.c
@@ -52,23 +52,37 @@ void cfd_set_default_path_mode(cfd_default_path_mode_t mode) {
     default_path_mode = mode;
 }
 
-const char* cfd_get_artifacts_path(void) {
-    static char default_path_buffer[512];
-
+const char* cfd_get_artifacts_path_internal(void) {
     if (strlen(artifacts_base_path) > 0) {
         return artifacts_base_path;
     }
 
     // Generate default path based on mode
+    static char default_base[512];  // Keep internal static for base path logic if needed, OR
+                                    // better: explicitly construct it.
+    // Actually, to fully remove static return buffers we should avoid returning pointers entirely.
+    // The previous implementation returned a pointer to a static buffer.
+    // We will keep 'artifacts_base_path' as configuration state, but for defaults we need a
+    // strategy.
+
+    // Let's implement the copy logic directly.
+    return NULL;
+}
+
+void cfd_get_artifacts_path(char* buffer, size_t size) {
+    if (!buffer || size == 0)
+        return;
+
+    if (strlen(artifacts_base_path) > 0) {
+        strncpy(buffer, artifacts_base_path, size - 1);
+        buffer[size - 1] = '\0';
+        return;
+    }
+
+    // Generate default path based on mode
     switch (default_path_mode) {
         case CFD_PATH_CURRENT_DIR:
-#ifdef _WIN32
-            strncpy(default_path_buffer, ".", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
-#else
-            strncpy(default_path_buffer, ".", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
-#endif
+            strncpy(buffer, ".", size - 1);
             break;
 
         case CFD_PATH_TEMP_DIR:
@@ -79,40 +93,31 @@ const char* cfd_get_artifacts_path(void) {
                 temp_dir = getenv("TMP");
             if (!temp_dir)
                 temp_dir = "C:\\temp";
-            snprintf(default_path_buffer, sizeof(default_path_buffer), "%s", temp_dir);
+            snprintf(buffer, size, "%s", temp_dir);
         }
 #else
         {
             char* temp_dir = getenv("TMPDIR");
             if (!temp_dir)
                 temp_dir = "/tmp";
-            snprintf(default_path_buffer, sizeof(default_path_buffer), "%s", temp_dir);
+            snprintf(buffer, size, "%s", temp_dir);
         }
 #endif
         break;
 
         case CFD_PATH_RELATIVE_BUILD:
 #ifdef _WIN32
-            strncpy(default_path_buffer, "..\\..\\artifacts", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
+            strncpy(buffer, "..\\..\\artifacts", size - 1);
 #else
-            strncpy(default_path_buffer, "../../artifacts", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
+            strncpy(buffer, "../../artifacts", size - 1);
 #endif
             break;
 
         default:
-#ifdef _WIN32
-            strncpy(default_path_buffer, ".", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
-#else
-            strncpy(default_path_buffer, ".", sizeof(default_path_buffer) - 1);
-            default_path_buffer[sizeof(default_path_buffer) - 1] = '\0';
-#endif
+            strncpy(buffer, ".", size - 1);
             break;
     }
-
-    return default_path_buffer;
+    buffer[size - 1] = '\0';
 }
 
 void cfd_reset_artifacts_path(void) {
@@ -123,7 +128,8 @@ void cfd_reset_artifacts_path(void) {
 // PATH CONSTRUCTION
 //=============================================================================
 void make_output_path(char* buffer, size_t buffer_size, const char* filename) {
-    const char* base_path = cfd_get_artifacts_path();
+    char base_path[512];
+    cfd_get_artifacts_path(base_path, sizeof(base_path));
 
 #ifdef _WIN32
     snprintf(buffer, buffer_size, "%s\\output\\%s", base_path, filename);
@@ -133,7 +139,8 @@ void make_output_path(char* buffer, size_t buffer_size, const char* filename) {
 }
 
 void make_artifacts_path(char* buffer, size_t buffer_size, const char* subdir) {
-    const char* base_path = cfd_get_artifacts_path();
+    char base_path[512];
+    cfd_get_artifacts_path(base_path, sizeof(base_path));
 
     if (subdir && strlen(subdir) > 0) {
 #ifdef _WIN32
@@ -151,7 +158,7 @@ void make_artifacts_path(char* buffer, size_t buffer_size, const char* subdir) {
 // RUN DIRECTORY MANAGEMENT
 //=============================================================================
 
-static char current_run_directory[512] = {0};
+static char current_run_directory[512] = {0};  // Keep state, but no direct access
 
 void cfd_create_run_directory(char* buffer, size_t buffer_size) {
     cfd_create_run_directory_with_prefix(buffer, buffer_size, "run");
@@ -167,7 +174,9 @@ void cfd_create_run_directory_with_prefix(char* buffer, size_t buffer_size, cons
              t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
 
     // Create full path
-    const char* base_path = cfd_get_artifacts_path();
+    char base_path[512];
+    cfd_get_artifacts_path(base_path, sizeof(base_path));
+
 #ifdef _WIN32
     snprintf(buffer, buffer_size, "%s\\output\\%s", base_path, timestamp);
 #else
@@ -207,7 +216,9 @@ void cfd_create_run_directory_ex(char* buffer, size_t buffer_size, const char* s
              t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
 
     // Create full path
-    const char* base_path = cfd_get_artifacts_path();
+    char base_path[512];
+    cfd_get_artifacts_path(base_path, sizeof(base_path));
+
 #ifdef _WIN32
     snprintf(buffer, buffer_size, "%s\\output\\%s", base_path, timestamp);
 #else
@@ -235,8 +246,16 @@ void cfd_create_run_directory_ex(char* buffer, size_t buffer_size, const char* s
     current_run_directory[sizeof(current_run_directory) - 1] = '\0';
 }
 
-const char* cfd_get_run_directory(void) {
-    return current_run_directory[0] != '\0' ? current_run_directory : NULL;
+void cfd_get_run_directory(char* buffer, size_t size) {
+    if (!buffer || size == 0)
+        return;
+
+    if (current_run_directory[0] != '\0') {
+        strncpy(buffer, current_run_directory, size - 1);
+    } else {
+        buffer[0] = '\0';
+    }
+    buffer[size - 1] = '\0';
 }
 
 void cfd_reset_run_directory(void) {

--- a/lib/src/core/filesystem.c
+++ b/lib/src/core/filesystem.c
@@ -52,22 +52,6 @@ void cfd_set_default_path_mode(cfd_default_path_mode_t mode) {
     default_path_mode = mode;
 }
 
-const char* cfd_get_artifacts_path_internal(void) {
-    if (strlen(artifacts_base_path) > 0) {
-        return artifacts_base_path;
-    }
-
-    // Generate default path based on mode
-    static char default_base[512];  // Keep internal static for base path logic if needed, OR
-                                    // better: explicitly construct it.
-    // Actually, to fully remove static return buffers we should avoid returning pointers entirely.
-    // The previous implementation returned a pointer to a static buffer.
-    // We will keep 'artifacts_base_path' as configuration state, but for defaults we need a
-    // strategy.
-
-    // Let's implement the copy logic directly.
-    return NULL;
-}
 
 void cfd_get_artifacts_path(char* buffer, size_t size) {
     if (!buffer || size == 0)

--- a/lib/src/io/vtk_output.c
+++ b/lib/src/io/vtk_output.c
@@ -243,13 +243,12 @@ void write_vtk_flow_field(const char* filename, const FlowField* field, size_t n
 
 // New run-based output functions
 static void get_run_filepath(char* buffer, size_t buffer_size, const char* filename) {
-    const char* run_dir = cfd_get_run_directory();
+    char run_dir[512];
+    cfd_get_run_directory(run_dir, sizeof(run_dir));
 
     // If no run directory exists yet, create one
-    if (run_dir == NULL) {
-        char new_run_dir[512];
-        cfd_create_run_directory(new_run_dir, sizeof(new_run_dir));
-        run_dir = cfd_get_run_directory();
+    if (strlen(run_dir) == 0) {
+        cfd_create_run_directory(run_dir, sizeof(run_dir));
     }
 
     // Build full path


### PR DESCRIPTION
- Updated cfd_get_artifacts_path and cfd_get_run_directory to accept caller-provided buffers.
- Removed thread-unsafe static return buffers.
- Updated vtk_output.c to use new safe API.
- Verified with OutputPaths tests and full suite.