### PR TITLE
fix: Enforce strict grid convergence monotonicity now that CG Poisson…

### DIFF
--- a/tests/math/test_omp_consistency.c
+++ b/tests/math/test_omp_consistency.c
@@ -121,19 +121,8 @@ void test_cg_omp_vs_scalar(void) {
     TEST_ASSERT_EQUAL(CFD_SUCCESS, status);
     TEST_ASSERT_EQUAL(POISSON_CONVERGED, stats_scalar.status);
 
-    /* OMP backend requires OpenMP - skip if not compiled in */
-#ifndef CFD_ENABLE_OPENMP
-    cfd_free(x_scalar);
-    cfd_free(x_omp);
-    cfd_free(x_temp);
-    cfd_free(rhs);
-    poisson_solver_destroy(solver_scalar);
-    TEST_IGNORE_MESSAGE("OMP test skipped: OpenMP not enabled in this build");
-    return;
-#endif
-
-    bool omp_available = poisson_solver_backend_available(POISSON_BACKEND_OMP);
-    if (!omp_available) {
+    /* OMP backend requires OpenMP - skip at runtime if unavailable */
+    if (!poisson_solver_backend_available(POISSON_BACKEND_OMP)) {
         cfd_free(x_scalar);
         cfd_free(x_omp);
         cfd_free(x_temp);
@@ -245,19 +234,8 @@ void test_redblack_omp_vs_scalar(void) {
     TEST_ASSERT_EQUAL(CFD_SUCCESS, status);
     TEST_ASSERT_EQUAL(POISSON_CONVERGED, stats_scalar.status);
 
-    /* OMP backend requires OpenMP - skip if not compiled in */
-#ifndef CFD_ENABLE_OPENMP
-    cfd_free(x_scalar);
-    cfd_free(x_omp);
-    cfd_free(x_temp);
-    cfd_free(rhs);
-    poisson_solver_destroy(solver_scalar);
-    TEST_IGNORE_MESSAGE("OMP test skipped: OpenMP not enabled in this build");
-    return;
-#endif
-
-    bool omp_available = poisson_solver_backend_available(POISSON_BACKEND_OMP);
-    if (!omp_available) {
+    /* OMP backend requires OpenMP - skip at runtime if unavailable */
+    if (!poisson_solver_backend_available(POISSON_BACKEND_OMP)) {
         cfd_free(x_scalar);
         cfd_free(x_omp);
         cfd_free(x_temp);

--- a/tests/validation/test_cavity_reference.c
+++ b/tests/validation/test_cavity_reference.c
@@ -251,7 +251,6 @@ void test_grid_convergence(void) {
 
     size_t sizes[] = {17, 25, 33};
     double errors[3];
-    double prev_error = 1.0;
 
     for (int i = 0; i < 3; i++) {
         size_t n = sizes[i];
@@ -279,18 +278,26 @@ void test_grid_convergence(void) {
         }
         printf("\n");
 
-        /* Error should decrease or stay similar with refinement */
-        TEST_ASSERT_TRUE_MESSAGE(errors[i] <= prev_error + 0.02,
-            "Error increased significantly with grid refinement");
-        prev_error = errors[i];
+        /* Error must strictly decrease with grid refinement */
+        if (i > 0) {
+            TEST_ASSERT_TRUE_MESSAGE(errors[i] < errors[i - 1],
+                "Error must decrease with grid refinement (strict monotonicity)");
+        }
 
         free_centerline_data(&data);
         cavity_context_destroy(ctx);
     }
 
-    /* Finest grid should have lowest error */
-    TEST_ASSERT_TRUE_MESSAGE(errors[2] <= errors[0] + 0.02,
-        "Grid convergence: finest grid should have lower or similar error");
+    /* Finest grid must have lowest error */
+    TEST_ASSERT_TRUE_MESSAGE(errors[2] < errors[0],
+        "Grid convergence: finest grid must have lower error than coarsest");
+
+    /* Report convergence rates (informational — first-order BCs limit to ~O(h^1.5)) */
+    double h[] = {1.0 / 17, 1.0 / 25, 1.0 / 33};
+    for (int i = 0; i < 2; i++) {
+        double rate = log(errors[i] / errors[i + 1]) / log(h[i] / h[i + 1]);
+        printf("      Rate (%zu->%zu): %.2f\n", sizes[i], sizes[i + 1], rate);
+    }
 }
 
 /* ============================================================================

--- a/tests/validation/test_ghia_projection_cpu.c
+++ b/tests/validation/test_ghia_projection_cpu.c
@@ -60,7 +60,7 @@ void test_projection_cpu_grid_convergence(void) {
     printf("\n    Grid convergence study...\n");
 
     size_t sizes[] = {17, 25, 33};
-    double prev_rms = 1.0;
+    double errors[3];
 
     for (int i = 0; i < 3; i++) {
         size_t n = sizes[i];
@@ -79,18 +79,26 @@ void test_projection_cpu_grid_convergence(void) {
 
         TEST_ASSERT_TRUE_MESSAGE(result.success, result.error_msg);
 
-        printf("      %zux%zu: RMS_u=%.4f", n, n, result.rms_u_error);
-        if (result.rms_u_error > GHIA_TOLERANCE_MEDIUM) {
+        errors[i] = result.rms_u_error;
+
+        printf("      %zux%zu: RMS_u=%.4f", n, n, errors[i]);
+        if (errors[i] > GHIA_TOLERANCE_MEDIUM) {
             printf(" [ABOVE TARGET]");
         }
         printf("\n");
 
         /* Error must strictly decrease with grid refinement */
         if (i > 0) {
-            TEST_ASSERT_TRUE_MESSAGE(result.rms_u_error < prev_rms,
+            TEST_ASSERT_TRUE_MESSAGE(errors[i] < errors[i - 1],
                 "Error must decrease with grid refinement (strict monotonicity)");
         }
-        prev_rms = result.rms_u_error;
+    }
+
+    /* Report convergence rates (informational — first-order BCs limit to ~O(h^1.5)) */
+    double h[] = {1.0 / 17, 1.0 / 25, 1.0 / 33};
+    for (int i = 0; i < 2; i++) {
+        double rate = log(errors[i] / errors[i + 1]) / log(h[i] / h[i + 1]);
+        printf("      Rate (%zu->%zu): %.2f\n", sizes[i], sizes[i + 1], rate);
     }
 }
 

--- a/tests/validation/test_ghia_projection_cpu.c
+++ b/tests/validation/test_ghia_projection_cpu.c
@@ -85,9 +85,11 @@ void test_projection_cpu_grid_convergence(void) {
         }
         printf("\n");
 
-        /* Error should decrease or stay similar with refinement */
-        TEST_ASSERT_TRUE_MESSAGE(result.rms_u_error <= prev_rms + 0.02,
-            "Error increased significantly with grid refinement");
+        /* Error must strictly decrease with grid refinement */
+        if (i > 0) {
+            TEST_ASSERT_TRUE_MESSAGE(result.rms_u_error < prev_rms,
+                "Error must decrease with grid refinement (strict monotonicity)");
+        }
         prev_rms = result.rms_u_error;
     }
 }


### PR DESCRIPTION
## Summary
The projection solver was already switched from Red-Black SOR to CG, which resolved non-monotonic grid convergence (17x17: 0.046, 25x25: 0.037, 33x33: 0.032). Remove the +0.02 tolerance slack from grid convergence assertions, require strict error decrease with refinement, and add convergence rate reporting.

## Test plan
- [x] Grid convergence tests pass with strict monotonicity assertions
- [x] Convergence rate reporting added to test output
- [x] All existing validation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)